### PR TITLE
소셜 로그인 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	//json파싱
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	//json파싱
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,16 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	//jwt생성 유효성 검사
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
+	implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	implementation 'com.auth0:java-jwt:4.4.0'
+	implementation 'com.auth0:jwks-rsa:0.21.1'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2', 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/backend/univfit/UnivfitApplication.java
+++ b/src/main/java/backend/univfit/UnivfitApplication.java
@@ -2,8 +2,9 @@ package backend.univfit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class UnivfitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/backend/univfit/global/utils/JwtUtils.java
+++ b/src/main/java/backend/univfit/global/utils/JwtUtils.java
@@ -1,0 +1,47 @@
+package backend.univfit.global.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.time.Duration;
+import java.util.Date;
+
+public class JwtUtils {
+    public static String createAccessToken(String socialLoginInfo, Long socialPK, Long memberId, String secretKey){
+        Long expiredMs = Duration.ofHours(2).toMillis(); // 만료 시간 2시간
+        //token에 들어있는 유저 정보를 사용하기 위함
+        // token에 유저 정보 담기 위해 claim사용
+        Claims claims = Jwts.claims();
+        claims.put("socialLoginInfo", socialLoginInfo);
+        claims.put("socialPK", socialPK);
+        claims.put("memberId", memberId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, "access_token")
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact(); //jwt토큰 발행
+    }
+
+    /**
+     * 리프레쉬 토큰을 발급해주는 메소드이다.
+     * @param secretKey 토큰을 디코딩하기 위해 쓰이는 시크릿키
+     * @param expiredMs 만료시간 설정(2주로 설정함)
+     * @return
+     */
+    public static String createRefreshToken(String secretKey){
+        Long expiredMs = Duration.ofDays(14).toMillis();
+        Claims claims = Jwts.claims();
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, "refresh_token")
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact(); //jwt토큰 발행
+    }
+}

--- a/src/main/java/backend/univfit/global/utils/KakaoApi.java
+++ b/src/main/java/backend/univfit/global/utils/KakaoApi.java
@@ -1,0 +1,63 @@
+package backend.univfit.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.springframework.boot.json.JsonParser;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+
+
+@Slf4j
+public class KakaoApi {
+    public static String getUserInfo(String accessToken) {
+        String reqUrl = "https://kapi.kakao.com/v2/user/me";
+        String id = null;
+        try{
+            URL url = new URL(reqUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+            conn.setRequestProperty("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            int responseCode = conn.getResponseCode();
+            log.info("[KakaoApi.getUserInfo] responseCode : {}",  responseCode);
+
+            BufferedReader br;
+            if (responseCode >= 200 && responseCode <= 300) {
+                br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                br = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            String line = "";
+            StringBuilder responseSb = new StringBuilder();
+            while((line = br.readLine()) != null){
+                responseSb.append(line);
+            }
+            String result = responseSb.toString();
+            log.info("responseBody = {}", result);
+
+            br.close();
+
+            //카카오 응답 json파싱
+            JSONParser jsonParser = new JSONParser();
+            JSONObject object = (JSONObject) jsonParser.parse(result);
+            id = object.get("id").toString();
+
+
+
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+
+        return id;
+    }
+}

--- a/src/main/java/backend/univfit/global/utils/NaverApi.java
+++ b/src/main/java/backend/univfit/global/utils/NaverApi.java
@@ -1,0 +1,95 @@
+package backend.univfit.global.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NaverApi {
+    public static String getResponse(String accessToken) throws ParseException {
+        String header = "Bearer " + accessToken; // Bearer 다음에 공백 추가
+
+
+        String apiURL = "https://openapi.naver.com/v1/nid/me";
+
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", header);
+        String responseBody = get(apiURL,requestHeaders);
+
+        //네이버 응답 json파싱
+        JSONParser jsonParser = new JSONParser();
+        JSONObject object = (JSONObject) jsonParser.parse(responseBody);
+        JSONObject responseObject = (JSONObject) object.get("response");
+
+        return responseObject.get("id").toString();
+    }
+
+
+    private static String get(String apiUrl, Map<String, String> requestHeaders){
+        HttpURLConnection con = connect(apiUrl);
+        try {
+            con.setRequestMethod("GET");
+            for(Map.Entry<String, String> header :requestHeaders.entrySet()) {
+                con.setRequestProperty(header.getKey(), header.getValue());
+            }
+
+
+            int responseCode = con.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) { // 정상 호출
+                return readBody(con.getInputStream());
+            } else { // 에러 발생
+                return readBody(con.getErrorStream());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("API 요청과 응답 실패", e);
+        } finally {
+            con.disconnect();
+        }
+    }
+
+
+    private static HttpURLConnection connect(String apiUrl){
+        try {
+            URL url = new URL(apiUrl);
+            return (HttpURLConnection)url.openConnection();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("API URL이 잘못되었습니다. : " + apiUrl, e);
+        } catch (IOException e) {
+            throw new RuntimeException("연결이 실패했습니다. : " + apiUrl, e);
+        }
+    }
+
+
+    private static String readBody(InputStream body){
+        InputStreamReader streamReader = new InputStreamReader(body);
+
+
+        try (BufferedReader lineReader = new BufferedReader(streamReader)) {
+            StringBuilder responseBody = new StringBuilder();
+
+
+            String line;
+            while ((line = lineReader.readLine()) != null) {
+                responseBody.append(line);
+            }
+
+
+            return responseBody.toString();
+        } catch (IOException e) {
+            throw new RuntimeException("API 응답을 읽는데 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/backend/univfit/global/utils/NaverApi.java
+++ b/src/main/java/backend/univfit/global/utils/NaverApi.java
@@ -1,7 +1,6 @@
 package backend.univfit.global.utils;
 
-import com.fasterxml.jackson.core.JsonParser;
-import org.json.simple.JSONArray;
+
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -12,7 +11,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.ProtocolException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/backend/univfit/member/api/OnboardApi.java
+++ b/src/main/java/backend/univfit/member/api/OnboardApi.java
@@ -1,0 +1,25 @@
+package backend.univfit.member.api;
+
+import backend.univfit.global.ApiResponse;
+import backend.univfit.member.application.OnboardService;
+import backend.univfit.member.dto.login.response.LoginResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.parser.ParseException;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import static backend.univfit.global.ApiResponse.onSuccess;
+
+@RestController
+@RequiredArgsConstructor
+public class OnboardApi {
+    private final OnboardService onboardService;
+    @PostMapping("/login/{socialServiceNickName}")
+    public ApiResponse<LoginResponse> login(@PathVariable("socialServiceNickName") String sn,
+                                            @RequestHeader("socialAccessToken") String accessToken) throws ParseException {
+        return ApiResponse.onSuccess(onboardService.login(sn, accessToken));
+    }
+}

--- a/src/main/java/backend/univfit/member/application/OnboardService.java
+++ b/src/main/java/backend/univfit/member/application/OnboardService.java
@@ -1,42 +1,87 @@
 package backend.univfit.member.application;
 
+import backend.univfit.global.utils.JwtUtils;
 import backend.univfit.global.utils.KakaoApi;
 import backend.univfit.global.utils.NaverApi;
 import backend.univfit.member.dto.login.response.LoginResponse;
+import backend.univfit.member.entity.KakaoSocialLogin;
+import backend.univfit.member.entity.Member;
+import backend.univfit.member.entity.NaverSocialLogin;
+import backend.univfit.member.repository.KakaoSocialLoginRepository;
+import backend.univfit.member.repository.MemberRepository;
+import backend.univfit.member.repository.NaverSocialLoginRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.print.attribute.standard.MediaSize;
 import java.util.HashMap;
 import java.util.Map;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class OnboardService {
+    @Value("${jwt.secret}")
+    private String jwtSecret;
     private final String KAKAO = "kakao";
     private final String NAVER = "naver";
-    private final String SOCIAL_ACCESSTOKEN = "socialAccessToken";
 
-    /**
-     * 네이버 로그인 테스트
-     */
+    private final KakaoSocialLoginRepository kakaoSocialLoginRepository;
+    private final NaverSocialLoginRepository naverSocialLoginRepository;
 
 
     public LoginResponse login(String sn, String accessToken) throws ParseException {
         String socialId = null;
+        boolean isOnboarding = false;
+        Member member = null;
+        Long memberId = null;
+        Long socialLoginId = null;
+        String socialLoginPlatForm = null;
+        int flag = 0;
         // 카카오 로그인 했을 경우
         if(sn.equals(KAKAO)){
             socialId = KakaoApi.getUserInfo(accessToken);
+            KakaoSocialLogin kakaoSocialLogin = kakaoSocialLoginRepository.findByKakaoNumber(socialId);
+            if(kakaoSocialLogin == null){
+                kakaoSocialLogin = new KakaoSocialLogin();
+                kakaoSocialLogin.setKakaoNumber(socialId);
+                kakaoSocialLoginRepository.save(kakaoSocialLogin);
+                socialLoginId = kakaoSocialLogin.getId();
+                socialLoginPlatForm = KAKAO;
+            }
+            member = kakaoSocialLogin.getMember();
+
         }
         //네이버 로그인 했을 경우
         if(sn.equals(NAVER)){
             socialId = NaverApi.getResponse(accessToken);
+            NaverSocialLogin naverSocialLogin = naverSocialLoginRepository.findByNaverNumber(socialId);
+            if(naverSocialLogin == null){
+                naverSocialLogin = new NaverSocialLogin();
+                naverSocialLogin.setNaverNumber(socialId);
+                naverSocialLoginRepository.save(naverSocialLogin);
+                socialLoginId = naverSocialLogin.getId();
+                socialLoginPlatForm = NAVER;
+            }
+            member = naverSocialLogin.getMember();
         }
-        
-        log.info("social Id = {}", socialId);
 
-        return LoginResponse.of(true,2L,"", "");
+        if(member != null){
+            memberId = member.getId();
+            if(member.getMemberPrivateInfo() != null){
+                isOnboarding = true;
+            }
+        }
+
+        String ServiceAccessToken = JwtUtils.createAccessToken(socialLoginPlatForm, socialLoginId, memberId, jwtSecret);
+        String refreshToken = JwtUtils.createRefreshToken(jwtSecret);
+
+
+        return LoginResponse.of(memberId,isOnboarding,ServiceAccessToken, refreshToken);
 
     }
 

--- a/src/main/java/backend/univfit/member/application/OnboardService.java
+++ b/src/main/java/backend/univfit/member/application/OnboardService.java
@@ -1,0 +1,39 @@
+package backend.univfit.member.application;
+
+import backend.univfit.global.utils.NaverApi;
+import backend.univfit.member.dto.login.response.LoginResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.json.simple.parser.ParseException;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OnboardService {
+    private final String KAKAO = "kakao";
+    private final String NAVER = "naver";
+    private final String SOCIAL_ACCESSTOKEN = "socialAccessToken";
+
+    /**
+     * 네이버 로그인 테스트
+     */
+
+
+    public LoginResponse login(String sn, String accessToken) throws ParseException {
+        String socialId;
+        // 카카오 로그인 했을 경우
+        if(sn.equals(KAKAO)){
+            socialId = getKakaoId(socialHeader);
+        }
+        //네이버 로그인 했을 경우
+        if(sn.equals(NAVER)){
+            socialId = NaverApi.getResponse(accessToken);
+        }
+
+        return LoginResponse.of(true,2L,"", "");
+
+    }
+
+
+}

--- a/src/main/java/backend/univfit/member/application/OnboardService.java
+++ b/src/main/java/backend/univfit/member/application/OnboardService.java
@@ -1,8 +1,10 @@
 package backend.univfit.member.application;
 
+import backend.univfit.global.utils.KakaoApi;
 import backend.univfit.global.utils.NaverApi;
 import backend.univfit.member.dto.login.response.LoginResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
 import org.springframework.stereotype.Service;
 
@@ -10,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Service
+@Slf4j
 public class OnboardService {
     private final String KAKAO = "kakao";
     private final String NAVER = "naver";
@@ -21,15 +24,17 @@ public class OnboardService {
 
 
     public LoginResponse login(String sn, String accessToken) throws ParseException {
-        String socialId;
+        String socialId = null;
         // 카카오 로그인 했을 경우
         if(sn.equals(KAKAO)){
-            socialId = getKakaoId(socialHeader);
+            socialId = KakaoApi.getUserInfo(accessToken);
         }
         //네이버 로그인 했을 경우
         if(sn.equals(NAVER)){
             socialId = NaverApi.getResponse(accessToken);
         }
+        
+        log.info("social Id = {}", socialId);
 
         return LoginResponse.of(true,2L,"", "");
 

--- a/src/main/java/backend/univfit/member/dto/login/response/LoginResponse.java
+++ b/src/main/java/backend/univfit/member/dto/login/response/LoginResponse.java
@@ -7,19 +7,19 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 public class LoginResponse {
-    private Boolean isMember;
     private Long memberId;
+    private Boolean isOnboarding;
     private String accessToken;
     private String refreshToken;
 
     public static LoginResponse of(
-            Boolean isMember,
             Long memberId,
+            Boolean isOnboarding,
             String accessToken,
             String refreshToken
     ){
         return LoginResponse.builder()
-                .isMember(isMember)
+                .isOnboarding(isOnboarding)
                 .memberId(memberId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/backend/univfit/member/dto/login/response/LoginResponse.java
+++ b/src/main/java/backend/univfit/member/dto/login/response/LoginResponse.java
@@ -1,0 +1,28 @@
+package backend.univfit.member.dto.login.response;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class LoginResponse {
+    private Boolean isMember;
+    private Long memberId;
+    private String accessToken;
+    private String refreshToken;
+
+    public static LoginResponse of(
+            Boolean isMember,
+            Long memberId,
+            String accessToken,
+            String refreshToken
+    ){
+        return LoginResponse.builder()
+                .isMember(isMember)
+                .memberId(memberId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+ }

--- a/src/main/java/backend/univfit/member/entity/KakaoSocialLogin.java
+++ b/src/main/java/backend/univfit/member/entity/KakaoSocialLogin.java
@@ -1,0 +1,23 @@
+package backend.univfit.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoSocialLogin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "kakaoSocialLogin_id")
+    private Long id;
+
+    private String kakaoNumber;
+
+    @OneToOne
+    @Column(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/backend/univfit/member/entity/Member.java
+++ b/src/main/java/backend/univfit/member/entity/Member.java
@@ -16,4 +16,10 @@ public class Member {
     private Long id;
 
     private String nickName;
+
+    @OneToOne
+    @JoinColumn(name = "memberPrivateInfo_id")
+    private MemberPrivateInfo memberPrivateInfo;
+
+
 }

--- a/src/main/java/backend/univfit/member/entity/Member.java
+++ b/src/main/java/backend/univfit/member/entity/Member.java
@@ -1,0 +1,19 @@
+package backend.univfit.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String nickName;
+}

--- a/src/main/java/backend/univfit/member/entity/MemberPrivateInfo.java
+++ b/src/main/java/backend/univfit/member/entity/MemberPrivateInfo.java
@@ -9,15 +9,11 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KakaoSocialLogin {
+public class MemberPrivateInfo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "kakaoSocialLogin_id")
+    @Column(name = "memberPrivateInfo_id")
     private Long id;
 
-    private String kakaoNumber;
-
-    @OneToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+    private String schoolName;
 }

--- a/src/main/java/backend/univfit/member/entity/NaverSocialLogin.java
+++ b/src/main/java/backend/univfit/member/entity/NaverSocialLogin.java
@@ -1,0 +1,23 @@
+package backend.univfit.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NaverSocialLogin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "naverSocialLogin_id")
+    private Long id;
+
+    private String naverNumber;
+
+    @OneToOne
+    @Column(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/backend/univfit/member/entity/NaverSocialLogin.java
+++ b/src/main/java/backend/univfit/member/entity/NaverSocialLogin.java
@@ -18,6 +18,6 @@ public class NaverSocialLogin {
     private String naverNumber;
 
     @OneToOne
-    @Column(name = "member_id")
+    @JoinColumn(name = "member_id")
     private Member member;
 }

--- a/src/main/java/backend/univfit/member/repository/KakaoSocialLoginRepository.java
+++ b/src/main/java/backend/univfit/member/repository/KakaoSocialLoginRepository.java
@@ -1,0 +1,8 @@
+package backend.univfit.member.repository;
+
+import backend.univfit.member.entity.KakaoSocialLogin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KakaoSocialLoginRepository extends JpaRepository<KakaoSocialLogin, Long> {
+    KakaoSocialLogin findByKakaoNumber(String kakaoNumber);
+}

--- a/src/main/java/backend/univfit/member/repository/MemberRepository.java
+++ b/src/main/java/backend/univfit/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package backend.univfit.member.repository;
+
+import backend.univfit.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/backend/univfit/member/repository/NaverSocialLoginRepository.java
+++ b/src/main/java/backend/univfit/member/repository/NaverSocialLoginRepository.java
@@ -1,0 +1,8 @@
+package backend.univfit.member.repository;
+
+import backend.univfit.member.entity.NaverSocialLogin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NaverSocialLoginRepository extends JpaRepository<NaverSocialLogin, Long> {
+    NaverSocialLogin findByNaverNumber(String naverNumber);
+}


### PR DESCRIPTION
### ✏️ 관련 이슈
온보딩 API 구현
- #5 

---

### 📝 작업 내용
온보딩 API 구현
- 온보딩 관련 Entity 구축(kakaoSocialLogin, NaverSocialLogin, Member, MemberPrivateInfo)
- MemberPrivateInfo는 시간관계상 모든 속성들을 다 채우진 못했음(추후 온보딩 api구현 시 완성할 예정)
- 소셜 로그인 서비스 주관 accessToken을 헤더로 받아서 요청을 하면 백엔드 측에서는 소셜로그인 accessToken 검사 ->
통과 시 api응답 코드 생성 -> 클라이언트 측으로 부터 보내기 로직을 따름

---

### 🎸 기타 사항 or 추가 코멘트
질문사항있으면 카톡이나 질문 부탁드리고, 이상없다고 간주되면 바로 develop에 merge해도 무방 -> 대신 머지하면 알려주세요
저도 update branch해야하니까요



