### PR TITLE
[feat] : 맞춤 장학금 조회 api 구현

### DIFF
--- a/src/main/java/backend/univfit/domain/HealthCheckApi.java
+++ b/src/main/java/backend/univfit/domain/HealthCheckApi.java
@@ -1,0 +1,17 @@
+package backend.univfit.domain;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class HealthCheckApi {
+    @GetMapping("/")
+    public ResponseEntity<HttpStatus> hello() {
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    @GetMapping("/health-check")
+    public String check() {
+        return "hello";
+    }
+}

--- a/src/main/java/backend/univfit/domain/apply/api/AnnouncementApi.java
+++ b/src/main/java/backend/univfit/domain/apply/api/AnnouncementApi.java
@@ -1,0 +1,53 @@
+package backend.univfit.domain.apply.api;
+
+import backend.univfit.domain.apply.api.dto.response.AnnouncementDetailResponse;
+import backend.univfit.domain.apply.api.dto.response.AnnouncementListResponse;
+import backend.univfit.domain.apply.api.dto.response.ScholarShipFoundationResponse;
+import backend.univfit.domain.apply.application.AnnouncementService;
+import backend.univfit.domain.apply.api.dto.response.AnnouncementResponse;
+import backend.univfit.global.ApiResponse;
+import backend.univfit.global.argumentResolver.MemberInfoObject;
+import backend.univfit.global.argumentResolver.customAnnotation.MemberInfo;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/announcements")
+@RestController
+public class AnnouncementApi {
+    private final AnnouncementService announcementService;
+
+    /**
+     * 전체 장학금 전체 조회
+     * @param status
+     * @return
+     */
+    @GetMapping("")
+    public ApiResponse<AnnouncementListResponse> getAnnouncementList(@RequestParam(required = false, defaultValue = "ING") List<String> status/**,@RequestHeader("socialAccessToken") String accessToken**/) {
+        return ApiResponse.onSuccess(announcementService.getAnnouncementList(status));
+    }
+
+    /**
+     * 전체 장학금 세부정보 조회
+     * @param announcementId
+     * @return
+     */
+    @GetMapping("/{announcementId}")
+    public ApiResponse<AnnouncementDetailResponse> getAnnouncement(@PathVariable Long announcementId
+                                                                   /**,@MemberInfo MemberInfoObject memberInfoObject**/) {
+        return ApiResponse.onSuccess(announcementService.getAnnouncement(announcementId/**,memberInfoObject**/));
+    }
+
+
+    /**
+     * 재단 정보 조회
+     */
+    @GetMapping("/{announcementId}/scholarship-foundations")
+    public ApiResponse<ScholarShipFoundationResponse> getScholarShipFoundationContents(@PathVariable Long announcementId) {
+        return ApiResponse.onSuccess(announcementService.getScholarShipFoundationContents(announcementId));
+    }
+
+}

--- a/src/main/java/backend/univfit/domain/apply/api/FitAnnouncementApi.java
+++ b/src/main/java/backend/univfit/domain/apply/api/FitAnnouncementApi.java
@@ -1,0 +1,25 @@
+package backend.univfit.domain.apply.api;
+
+import backend.univfit.domain.apply.api.dto.response.AnnouncementListResponse;
+import backend.univfit.domain.apply.application.FitAnnouncementService;
+import backend.univfit.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RequestMapping("/announcements")
+@RestController
+public class FitAnnouncementApi {
+    private final FitAnnouncementService fitAnnouncementService;
+
+    @GetMapping("/recommendations")
+    public ApiResponse<AnnouncementListResponse> getAnnouncementList(@RequestParam String status
+                                                                     /**, @MemberInfo MemberInfoObject memberInfoObject**/) {
+        return ApiResponse.onSuccess(fitAnnouncementService.getAnnouncementList(status));
+    }
+
+}

--- a/src/main/java/backend/univfit/domain/apply/application/FitAnnouncementService.java
+++ b/src/main/java/backend/univfit/domain/apply/application/FitAnnouncementService.java
@@ -1,0 +1,9 @@
+package backend.univfit.domain.apply.application;
+
+import backend.univfit.domain.apply.api.dto.response.AnnouncementListResponse;
+
+import java.util.List;
+
+public interface FitAnnouncementService {
+    AnnouncementListResponse getAnnouncementList(String statuses);
+}

--- a/src/main/java/backend/univfit/domain/apply/application/FitAnnouncementServiceImpl.java
+++ b/src/main/java/backend/univfit/domain/apply/application/FitAnnouncementServiceImpl.java
@@ -1,0 +1,61 @@
+package backend.univfit.domain.apply.application;
+
+import backend.univfit.domain.apply.api.dto.response.AnnouncementListResponse;
+import backend.univfit.domain.apply.api.dto.response.AnnouncementResponse;
+import backend.univfit.domain.apply.entity.enums.AnnouncementStatus;
+import backend.univfit.domain.apply.repository.AnnouncementJpaRepository;
+import backend.univfit.domain.apply.repository.ConditionJpaRepository;
+import backend.univfit.domain.apply.repository.ScholarShipFoundationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FitAnnouncementServiceImpl implements FitAnnouncementService{
+    private final AnnouncementJpaRepository announcementJpaRepository;
+    private final AnnouncementManager announcementManager;
+    private final ConditionJpaRepository conditionJpaRepository;
+    //    private final MemberPrivateInfoJpaRepository memberPrivateInfoJpaRepository;
+//    private final MemberJpaRepository memberJpaRepository;
+    private final ScholarShipFoundationJpaRepository scholarShipFoundationJpaRepository;
+
+    @Override
+    public AnnouncementListResponse getAnnouncementList(String status) {
+        List<AnnouncementResponse> list = announcementJpaRepository.findAll().stream()
+                .map(ar -> {
+                    ar.updateStatus(LocalDate.now());
+                    announcementJpaRepository.save(ar);
+                    return ar;
+                })
+                .map(ar -> {
+                    String announcementStatus = announcementManager.checkAnnouncementStatus(ar);
+                    long remainingDay = ChronoUnit.DAYS.between(LocalDate.now(), ar.getEndDocumentDate());
+                    String remainingDaysToString = "D-" + remainingDay;
+                    String applyPossible = announcementManager.checkEligibility(ar, 1L);
+
+                    return AnnouncementResponse.of(ar.getId(),
+                            ar.getScholarShipName(), ar.getScholarShipFoundation(), announcementStatus,
+                            ar.getApplicationPeriod(), remainingDaysToString, applyPossible
+                    );
+                })//여기 고쳐야함
+                .filter(ar -> {
+                    if (status.equals("전체")) {
+                        return ar.applyPossible().equals("판단불가") || ar.applyPossible().equals("지원대상");
+                    } else if (status.equals("바로지원가능")) {
+                        return ar.applyPossible().equals("지원대상");
+                    } else {
+                        return ar.scholarshipStatus().contains(status);
+                    }
+                })
+                .toList();
+
+        return AnnouncementListResponse.of(list, list.size());
+    }
+
+
+}


### PR DESCRIPTION
status는 '전체' 혹은 '바로지원가능'

### ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- #13 

---

### 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 맞춤 장학금 조회 api 구현
- healthcheck 추가 

---

### 🎸 기타 사항 or 추가 코멘트
status가 '전체' 이면 지원대상 혹은 판단불가 상태 모두 반환
status가 '바로지원가능' 이면 지원대상 상태만 모두 반환 



